### PR TITLE
Autofill configuration

### DIFF
--- a/ArchipelAgent/archipel-agent/install/bin/archipel-initinstall
+++ b/ArchipelAgent/archipel-agent/install/bin/archipel-initinstall
@@ -21,10 +21,14 @@ import os
 import sqlite3
 import sys
 import shutil
+import string
+import uuid
+from socket import gethostname, getfqdn
+from random import choice
 from optparse import OptionParser
 
 
-def prepare_environment(prefix="", force=False):
+def prepare_environment(prefix="", force=False, xmpp_server="auto", hypervisor_name="auto"):
     from pkg_resources import Requirement, resource_filename
     import errno
     init_script     = resource_filename(Requirement.parse("archipel-agent"),"install/etc/init.d/archipel")
@@ -74,6 +78,24 @@ def prepare_environment(prefix="", force=False):
         shutil.copytree(conf_folder, "%s/etc/archipel/" % prefix)
         os.system("chmod 600 '%s/etc/archipel/archipel.conf'" % prefix)
         print "      \033[32m[OK]\033[0m"
+
+        sys.stdout.write(" - pre-configuring %s/etc/archipel/archipel.conf:" % prefix)
+        conf_in = open("%s/archipel.conf" % conf_folder)
+        conf_out = open("%s/etc/archipel/archipel.conf" % prefix, "w")
+        uuidgen = str(uuid.uuid4())
+        if hypervisor_name == "default":
+            hypervisor_name = gethostname()
+        if xmpp_server == "default":
+            xmpp_server = getfqdn()
+        hypervisor_password = ''.join([choice(string.letters + string.digits) for i in xrange(8)])
+        for line in conf_in:
+            line = line.replace("PARAM_UUID",uuidgen)
+            line = line.replace("PARAM_HYPERVISOR_NAME", hypervisor_name)
+            line = line.replace("PARAM_HYPERVISOR_PASSWORD", hypervisor_password)
+            line = line.replace("PARAM_XMPP_SERVER", xmpp_server)
+            conf_out.write(line)
+        conf_in.close()
+        conf_out.close()
     except OSError as (n, strerror):
         if n == errno.ENOENT:
             print "      \033[31m[ERROR]\033[0m"
@@ -124,7 +146,17 @@ if __name__ == "__main__":
                         help="before installing, clean all existing folder and files. IT WILL DESTROY YOUR CURRENT INSTALLATION, VM DRIVES etc. Be warned!",
                         metavar="SERVER",
                         default=False)
+    parser.add_option("-x", "--xmpp-server",
+                        dest="xmpp_server",
+                        help="set the fqdn of the XMPP server, defaults to local fqdn",
+                        metavar="FQDN",
+                        default="auto")
+    parser.add_option("-n", "--name",
+                        dest="hypervisor_name",
+                        help="set the name of the hypervisor (left part of the JID), defaults to <hostname>",
+                        metavar="SERVER",
+                        default="auto")
 
     options, args = parser.parse_args()
 
-    prepare_environment(options.prefix, options.clean)
+    prepare_environment(options.prefix, options.clean, options.xmpp_server, options.hypervisor_name)

--- a/ArchipelAgent/archipel-agent/install/etc/archipel/archipel.conf
+++ b/ArchipelAgent/archipel-agent/install/etc/archipel/archipel.conf
@@ -28,7 +28,7 @@
 [DEFAULT]
 
 # the default XMPP server to user
-xmpp_server                 = REPLACE_THIS_WITH_YOUR_XMPP_SERVER_FQDN
+xmpp_server                 = PARAM_XMPP_SERVER
 
 # archipel's data folder
 archipel_folder_lib         = /var/lib/archipel/
@@ -37,7 +37,7 @@ archipel_folder_lib         = /var/lib/archipel/
 # internally. It MUST be different foreach one over
 # your platform. You can generate a new one using
 # uuidgen command
-archipel_general_uuid       = a933cf21-d64a-3f9b-929e-449ac88fc353
+archipel_general_uuid       = PARAM_UUID
 
 # the base working folder, where virtual machine related
 # stuff will be stored
@@ -95,12 +95,13 @@ url         = http://archipelproject.org
 #
 [HYPERVISOR]
 
-# the JID of this hypervisor.
+# the JID of this hypervisor. It MUST be different foreach one over
+# your platform.
 # If this account not exists, it will be created on the fly
-hypervisor_xmpp_jid         = hypervisor@%(xmpp_server)s
+hypervisor_xmpp_jid         = PARAM_HYPERVISOR_NAME@%(xmpp_server)s
 
 # the XMPP password of this hypervisor
-hypervisor_xmpp_password    = password
+hypervisor_xmpp_password    = PARAM_HYPERVISOR_PASSWORD
 
 # the vCard name of hypervisor. if set to "auto"
 # the hostname is used


### PR DESCRIPTION
- generate an uuid when running archipel-initinstall
- add a parameter  --xmpp-server to archipel-initinstall
- fill in archipel.conf:
  - xmpp_server = the  --xmpp-server commandline parameter
  - archipel_general_uuid = the generated uuid
  - hypervisor_xmpp_jid = FQDN@%(xmpp_server)s
  - hypervisor_xmpp_password = a random generated password

See also: https://github.com/primalmotion/Archipel/issues/153
