### PR TITLE
Fixes for QCOW Golden Images on Debian stable

### DIFF
--- a/ArchipelAgent/archipel-agent-virtualmachine-storage/archipelagentvirtualmachinestorage/storage.py
+++ b/ArchipelAgent/archipel-agent-virtualmachine-storage/archipelagentvirtualmachinestorage/storage.py
@@ -384,7 +384,9 @@ class TNStorageManagement (TNArchipelPlugin):
             nodes = []
             goldens = os.listdir(self.golden_drives_dir)
             for golden in goldens:
-                if subprocess.Popen(["file", os.path.join(self.golden_drives_dir, golden)], stdout=subprocess.PIPE).communicate()[0].lower().find("format: qcow") > -1:
+                file_cmd_output = subprocess.Popen(["file", os.path.join(self.golden_drives_dir, golden)], stdout=subprocess.PIPE).communicate()[0].lower()
+                if file_cmd_output.find("format: qcow") > -1 \
+                or file_cmd_output.find("qemu qcow image") > -1:
                     node = xmpp.Node(tag="golden", attrs={"name": golden, "path": os.path.join(self.golden_drives_dir, golden)})
                     nodes.append(node)
             reply = iq.buildReply("result")


### PR DESCRIPTION
File(1) on Debian Stable outputs the results in a slightly different way than is coded into the current version of the storage class. This is took into account for disk image lookups but not for golden images. 

This patchset fixes that and also replaces the subprocess calls for "ls" with listdir, and replaces some of the static path construction with os.path.join.
