### PR TITLE
Try using /usr/local/bin/runarchipel as archipel-agent binary if 'which runarchipel' fails. Should fix #212

### DIFF
--- a/ArchipelAgent/archipel-agent/install/etc/init.d/archipel
+++ b/ArchipelAgent/archipel-agent/install/etc/init.d/archipel
@@ -34,12 +34,9 @@ if [ $? -eq 1 ]; then
     exit 1
   fi
 fi
-
 PROG=$(basename $ARCHIPEL)
 PROGNAME="Archipel"
 ARCHIPEL_CONF_FILE="/etc/archipel/archipel.conf"
-
-
 
 if [[ -d /var/lock/subsys ]]; then
     lockfile=/var/lock/subsys/archipel


### PR DESCRIPTION
Try using /usr/local/bin/runarchipel as archipel-agent binary if 'which runarchipel' fails. Should fix #212
