### PR TITLE
Micro change on init script

### DIFF
--- a/ArchipelAgent/archipel-agent/install/etc/init.d/archipel
+++ b/ArchipelAgent/archipel-agent/install/etc/init.d/archipel
@@ -76,7 +76,7 @@ stop() {
     fi
 
     echo -ne " * Stopping $PROGNAME:\\r"
-    killall -9 $PROG
+    killall -w $PROG
     retval=$?
     rm -f $lockfile
     echo -ne " * Stopping $PROGNAME: \\033[32m[OK]\\033[0m\\n"


### PR DESCRIPTION
its bad idea to kill any python application with kill signal, its causes object files to not get removed correctly.

on the other hand, waiting for application to gracefully shut itself down is a pretty good idea, not waiting for it might cause serious problem with not being able to cleanly unmount /vm partition (because its already in use) during shutdown.
