### PR TITLE
fix vms info that gets stored in parking db

### DIFF
--- a/ArchipelAgent/archipel-agent-vmparking/archipelagentvmparking/vmparking.py
+++ b/ArchipelAgent/archipel-agent-vmparking/archipelagentvmparking/vmparking.py
@@ -118,7 +118,7 @@ class TNVMParking (TNArchipelPlugin):
         xmldesc = self.entity.xmldesc(mask_description=False)
 
         if not hypervisor_parking_plugin.is_vm_registered(self.entity.uuid):
-            vms_info = [{"uuid": self.entity.uuid, "domain": xmldesc, "parker": "nobody", "status": ARCHIPEL_PARKING_STATUS_NOT_PARKED, "date": datetime.datetime.now()}]
+            vms_info = [{"uuid": self.entity.uuid, "domain": str(xmldesc), "parker": "nobody", "status": ARCHIPEL_PARKING_STATUS_NOT_PARKED, "creation_date": datetime.datetime.now()}]
             hypervisor_parking_plugin.register_vms_into_db(vms_info)
         else:
             hypervisor_parking_plugin.update_vm_domain_in_db(self.entity.uuid, xmldesc)


### PR DESCRIPTION
fixes: error during performing method hook_vm_define for hookname
HOOK_VM_DEFINE: You did not supply a value for binding 3
