### PR TITLE
don't display duplicats in disk stats. fixed #575

### DIFF
--- a/ArchipelAgent/archipel-agent-hypervisor-health/archipelagenthypervisorhealth/archipelStatsCollector.py
+++ b/ArchipelAgent/archipel-agent-hypervisor-health/archipelagenthypervisorhealth/archipelStatsCollector.py
@@ -212,11 +212,15 @@ class TNThreadedHealthCollector (Thread):
         @return: dictionnary containing the informations
         """
         output  = subprocess.Popen(["df", "-P"], stdout=subprocess.PIPE).communicate()[0]
+        listed  = []
         ret     = []
         out     = output.split("\n")[1:-1]
         for l in out:
             cell = l.split()
+            if cell[5] in listed:
+                continue
             ret.append({"partition": cell[0], "blocks": cell[1], "used": int(cell[2]) * 1024, "available": int(cell[3]) * 1024, "capacity": cell[4], "mount": cell[5]})
+            listed.append(cell[5])
         return ret
 
     def get_network_stats(self):


### PR DESCRIPTION
sometimes output of df has duplicates like below, which is not what we
want to show to user in Archipel's health.

$ df -P
Filesystem     1024-blocks    Used Available Capacity Mounted on
rootfs            15481840 5932212   8763196      41% /
dev                1980788       0   1980788       0% /dev
run                1983520     640   1982880       1% /run
/dev/sdb1         15481840 5932212   8763196      41% /
shm                1983520     176   1983344       1% /dev/shm
tmpfs              1983520     224   1983296       1% /tmp
/dev/sdb3         43994264 7074672  34684816      17% /home
