### PR TITLE
hypervisor should handle libvirt disconnection of VMs

### DIFF
--- a/ArchipelAgent/archipel-agent/archipel/archipelLibvirtEntity.py
+++ b/ArchipelAgent/archipel-agent/archipel/archipelLibvirtEntity.py
@@ -144,15 +144,15 @@ class TNArchipelLibvirtEntity (object):
             status = "dnd"
             message = "trying to recover libvirt connection"
             self.change_presence(status, message)
+            for uuid, vm in self.virtualmachines.iteritems():
+                vm.change_presence(status, message)
         else:
-            if hasattr(self, 'set_presence_according_to_libvirt_info'):
-                self.connect_libvirt()
-                self.domain = None
-                self.connect_domain()
-                self.set_presence_according_to_libvirt_info()
-            else:
-                self.xmppstatusshow = ""
-                self.update_presence()
+            self.xmppstatusshow = ""
+            self.update_presence()
+            for uuid, vm in self.virtualmachines.iteritems():
+                vm.domain = None
+                vm.connect_domain()
+                vm.set_presence_according_to_libvirt_info()
 
     def check_libvirt_connection(self):
         """


### PR DESCRIPTION
we've one connection for all entities (based on 431c896889d570678ffa4f0aa75530d32dfc3ce0) so hypervisor itself should handle libvirt disconnection(s).
