### PR TITLE
features should be set once in VM Definition

### DIFF
--- a/ArchipelClient/ModulesSources/VirtualMachineDefinition/TNVirtualMachineDefinitionController.j
+++ b/ArchipelClient/ModulesSources/VirtualMachineDefinition/TNVirtualMachineDefinitionController.j
@@ -2373,7 +2373,9 @@ var TNArchipelDefinitionUpdatedNotification             = @"TNArchipelDefinition
     _libvirtDomain = [[TNLibvirtDomain alloc] initWithXMLNode:[aStanza firstChildWithName:@"domain"]];
 
     [self selectGuestWithType:[[[_libvirtDomain OS] type] type] architecture:[[[_libvirtDomain OS] type] architecture]];
-    [self buildGUIAccordingToCurrentGuest];
+    // we don't need call to buildGUIAccordingToCurrentGuest cause enabelGUI
+    // will call it if UI should be enabled
+    [self enableGUI:([_entity XMPPShow] == TNStropheContactStatusBusy)];
 
     // button domainType
     [buttonDomainType selectItemWithTitle:[_libvirtDomain type]];
@@ -2524,7 +2526,6 @@ var TNArchipelDefinitionUpdatedNotification             = @"TNArchipelDefinition
 
     _definitionRecovered = YES;
     [self handleDefinitionEdition:NO];
-    [self enableGUI:([_entity XMPPShow] == TNStropheContactStatusBusy)];
 
     return NO;
 }


### PR DESCRIPTION
VM PAE / ACPI / APCI values get overrided by capabilities cause we call
buildGUIAccordingToCurrentGuest after setting value of them.
