### PR TITLE
disable auto validation on toolbar items. fix #602

### DIFF
--- a/ArchipelClient/Controllers/TNModuleController.j
+++ b/ArchipelClient/Controllers/TNModuleController.j
@@ -487,6 +487,12 @@ TNArchipelModulesVisibilityRequestNotification  = @"TNArchipelModulesVisibilityR
         frame                   = [_mainModuleView bounds],
         moduleToolbarItem       = [[CPToolbarItem alloc] initWithItemIdentifier:moduleIdentifier];
 
+    // auto validating of toolbar item should be disabled so
+    // they won't get enabled by theirselves when user clicks
+    // somewhere. for more info take a look at:
+    // https://github.com/ArchipelProject/Archipel/issues/602
+    [moduleToolbarItem setAutovalidates:NO];
+
     if ([moduleLabel isKindOfClass:CPDictionary] && bundleLocale)
         moduleLabel = [moduleLabel objectForKey:[defaults objectForKey:@"CPBundleLocale"]] || [moduleLabel objectForKey:@"en"];
 


### PR DESCRIPTION
when auto validate is enabled and user clicks somewhere that doesn't
capture click event, the CPWindowDidChangeFirstResponderNotification
causes toolbars to be revalidated and enabled again, which is not what
we want.
