### PR TITLE
Fix #468 Reset roster filter and reload data

### DIFF
--- a/ArchipelClient/Views/TNOutlineViewRoster.j
+++ b/ArchipelClient/Views/TNOutlineViewRoster.j
@@ -144,6 +144,8 @@ TNArchipelRosterOutlineViewSelectItemNotification   = @"TNArchipelRosterOutlineV
 
     var rowIndex = [self rowForItem:[aNotification userInfo]];
     if (rowIndex !== CPNotFound)
+        [[_searchField cancelButton] performClick:self];
+        [self reloadData];
         [self selectRowIndexes:[CPIndexSet indexSetWithIndex:rowIndex] byExtendingSelection:NO];
 }
 


### PR DESCRIPTION
Not sure about the way, but I test a lot of other things and the only way is to clear the filter and force reload the data. (If we don't reload the data, I think the selectRowIdexes is fired to fast after reseting the filter).
