### PR TITLE
Added replacement of unhandled char in xen vm name

### DIFF
--- a/ArchipelAgent/archipel-agent/install/etc/archipel/archipel.conf
+++ b/ArchipelAgent/archipel-agent/install/etc/archipel/archipel.conf
@@ -157,6 +157,7 @@ maximum_lock_time               = 1
 vm_permissions_database_path    = /permissions.sqlite3
 
 # if set to false, all space in virtual machine names will be replaced by a '-'
+# note that for xen backend this option has no effect as xen does'nt handle spaces in names.
 allow_blank_space_in_vm_name    = True
 
 # [OPTIONAL] this will allow to block access to block devices


### PR DESCRIPTION
Make the disallow_spaces_in_name = true is Hypervisor type is XEN
Add a list of unhandled char and delete them if Hypervisor is XEN

Possible fix por #586
