### PR TITLE
Except properly if KSM not available

### DIFF
--- a/ArchipelAgent/archipel-agent-hypervisor-health/archipelagenthypervisorhealth/archipelStatsCollector.py
+++ b/ArchipelAgent/archipel-agent-hypervisor-health/archipelagenthypervisorhealth/archipelStatsCollector.py
@@ -170,10 +170,13 @@ class TNThreadedHealthCollector (Thread):
         file_meminfo = open('/proc/meminfo')
         meminfo = file_meminfo.read()
         file_meminfo.close()
-        file_pages_sharing = open("/sys/kernel/mm/ksm/pages_sharing")
-        pagessharing = file_pages_sharing.read()
-        file_pages_sharing.close()
-        memshared = int(pagessharing) * self.memoryPageSize / 1024;
+        try:
+            file_pages_sharing = open("/sys/kernel/mm/ksm/pages_sharing")
+            pagessharing = file_pages_sharing.read()
+            file_pages_sharing.close()
+            memshared = int(pagessharing) * self.memoryPageSize / 1024;
+        except:
+            memshared = 0
         meminfolines = meminfo.split("\n")
         memTotal = int(meminfolines[0].split()[1])
         memFree = int(meminfolines[1].split()[1]) + int(meminfolines[2].split()[1]) + int(meminfolines[3].split()[1])


### PR DESCRIPTION
Signed-off-by: Jonathan Raffre jonathan.raffre@nekolover.net

In the current version, the Archipel Agent open forcefully /sys/kernel/mm/ksm/pages_sharing , even if it does not exists (this is the case on older kernels). 

This commit make this open safe and set memshared value to 0 if not found (which is the expected behavior, as there is no shared memory if KSM is not available).
