### PR TITLE
show error and stacktrace in archipel-command

### DIFF
--- a/ArchipelAgent/archipel-agent/install/bin/archipel-command
+++ b/ArchipelAgent/archipel-agent/install/bin/archipel-command
@@ -66,7 +66,5 @@ if __name__ == "__main__":
         send_raw(xmppclient, xmpp.JID(options.dest_jid), options.send_raw, options.nopretty_output)
     else:
         data = "".join(sys.stdin.readlines())
-        try:
-            send_raw(xmppclient, xmpp.JID(options.dest_jid), data, options.nopretty_output)
-        except Exception as ex:
-            error("the data from stdin are not well formed")
+        send_raw(xmppclient, xmpp.JID(options.dest_jid), data, options.nopretty_output)
+


### PR DESCRIPTION
It's hard to tell what the problem is when an error and stacktrace are ignored.
