### PR TITLE
Cannot add some ISO files after file-5.15 update (one time fix)

### DIFF
--- a/ArchipelAgent/archipel-agent-virtualmachine-storage/archipelagentvirtualmachinestorage/storage.py
+++ b/ArchipelAgent/archipel-agent-virtualmachine-storage/archipelagentvirtualmachinestorage/storage.py
@@ -177,7 +177,7 @@ class TNStorageManagement (TNArchipelPlugin):
         @param path: the path of the file to check
         """
         output = magic.from_file(path).lower()
-        return "iso 9660" in output or "x86 boot sector" in output
+        return "iso 9660" in output or "x86 boot sector" in output or "dos/mbr boot sector" in output
 
 
     ### XMPP Processing


### PR DESCRIPTION
The same problem as in #811. file-5.15 changed some names and it doesn't work once again. Here's a fix for this.
#971 is better in my opinion but you choose. ;)
