### PR TITLE
Cannot add some ISO files after file-5.15 update (permanent fix)

### DIFF
--- a/ArchipelAgent/archipel-agent-virtualmachine-storage/archipelagentvirtualmachinestorage/storage.py
+++ b/ArchipelAgent/archipel-agent-virtualmachine-storage/archipelagentvirtualmachinestorage/storage.py
@@ -135,7 +135,7 @@ class TNStorageManagement (TNArchipelPlugin):
         @type path: string
         @param path: the path of the file to check
         """
-        return self._is_file_a("cow", path, ("user-mode linux cow file"))
+        return self._is_file_a("cow", path, ("user-mode linux cow file",))
 
     def _is_file_a_qcow(self, path):
         """
@@ -167,7 +167,7 @@ class TNStorageManagement (TNArchipelPlugin):
         @type path: string
         @param path: the path of the file to check
         """
-        return self._is_file_a("vmdk", path, ("vmware"))
+        return self._is_file_a("vmdk", path, ("vmware",))
 
     def _is_file_an_iso(self, path):
         """


### PR DESCRIPTION
The same problem as in #811. file-5.15 changed some names and it doesn't work once again. Here's a fix that will make this issue **never** come back.
