### PR TITLE
don't fork when run from systemd #972

### DIFF
--- a/ArchipelAgent/archipel-agent/install/usr/lib/systemd/system/archipel-agent.service
+++ b/ArchipelAgent/archipel-agent/install/usr/lib/systemd/system/archipel-agent.service
@@ -4,9 +4,10 @@ Requires=libvirtd.service
 After=libvirtd.service
 
 [Service]
-ExecStart=/usr/bin/runarchipel --config=/etc/archipel/archipel.conf
-Type=forking
-RemainAfterExit=yes
+ExecStart=/usr/bin/runarchipel --config=/etc/archipel/archipel.conf --nofork
+Type=simple
+Restart=always
 
 [Install]
 WantedBy=multi-user.target
+


### PR DESCRIPTION
Unit file for systemd. Systemd, contrary to System V Init, is not a set of scripts and processes don't need to daemonize themselves because they are already daemonized by systemd. systemd runs the process from parent PID 1, stdout/stderr are redirected to systemd-journald, and the process doesn't own tty. For these reasons, Archipel doesn't need to daemonize itself because it's already daemonized by systemd. Just like php-fpm doesn't, and lots of other applications don't. https://bugs.php.net/patch-display.php?bug=63085&patch=php-fpm-systemd.patch&revision=1348066817
