### PR TITLE
remove "success" message from archipel-command as it brings no real value

### DIFF
--- a/ArchipelAgent/archipel-agent/install/bin/archipel-command
+++ b/ArchipelAgent/archipel-agent/install/bin/archipel-command
@@ -31,7 +31,6 @@ def send_raw(xmppclient, to, acp, pretty):
     """
     out = send_raw_acp(xmppclient, to, acp)
     if pretty:
-        success("Answer received: ")
         print xml_print(out)
     else:
         print out


### PR DESCRIPTION
The first line has no real value but makes greping, parsing and other things much more complicated.
