### PR TITLE
fix exit code for service status

### DIFF
--- a/ArchipelAgent/archipel-agent/install/etc/init.d/archipel
+++ b/ArchipelAgent/archipel-agent/install/etc/init.d/archipel
@@ -95,7 +95,7 @@ status() {
         exit 0
     else
         echo -ne " * $PROGNAME state: \\033[31m[STOPPED]\\033[0m\\n"
-        exit 1
+        exit 3
     fi
 
 }

--- a/ArchipelAgent/archipel-central-agent/install/etc/init.d/archipel-central-agent
+++ b/ArchipelAgent/archipel-central-agent/install/etc/init.d/archipel-central-agent
@@ -93,7 +93,7 @@ status() {
         exit 0
     else
         echo -ne " * $PROGNAME state: \\033[31m[STOPPED]\\033[0m\\n"
-        exit 1
+        exit 3
     fi
 
 }


### PR DESCRIPTION
should return as error when daemon is not running
see
http://docs.puppetlabs.com/guides/troubleshooting.html#why-does-puppet-keep-trying-to-start-a-running-service
