### PR TITLE
Fixed: Crash when selecting a collapsed VM from a hypervisor

### DIFF
--- a/ArchipelClient/Views/TNOutlineViewRoster.j
+++ b/ArchipelClient/Views/TNOutlineViewRoster.j
@@ -141,11 +141,22 @@ TNArchipelRosterOutlineViewSelectItemNotification   = @"TNArchipelRosterOutlineV
     }
 
     var rowIndex = [self rowForItem:[aNotification userInfo]];
+
+    if (rowIndex == CPNotFound)
+    {
+        var group = [[[aNotification userInfo] groups] firstObject];
+        [self expandItem:group];
+
+        rowIndex = [self rowForItem:[aNotification userInfo]];
+    }
+
     if (rowIndex !== CPNotFound)
         [[_searchField cancelButton] performClick:self];
-        [self reloadData];
-        [self selectRowIndexes:[CPIndexSet indexSetWithIndex:rowIndex] byExtendingSelection:NO];
+
+    [self reloadData];
+    [self selectRowIndexes:[CPIndexSet indexSetWithIndex:rowIndex] byExtendingSelection:NO];
 }
+
 
 #pragma mark -
 #pragma mark Utilities


### PR DESCRIPTION
Previously, when selecting a collapsed VM from the Hypervisor, the application crashed.
Now it firstly expand the group of the VM and then select the VM.
