### PR TITLE
Fixed typo in XMPPServer "Grant selected user(s) as admin" star tooltip.

### DIFF
--- a/ArchipelClient/ModulesSources/ToolbarXMPPServer/Resources/en.lproj/Localizable.strings
+++ b/ArchipelClient/ModulesSources/ToolbarXMPPServer/Resources/en.lproj/Localizable.strings
@@ -28,8 +28,8 @@
 /* Delete selected shared group */
 "Delete selected shared group" = "Delete selected shared group";
 
-/* Grand selected user(s) as admin */
-"Grand selected user(s) as admin" = "Grand selected user(s) as admin";
+/* Grant selected user(s) as admin */
+"Grant selected user(s) as admin" = "Grant selected user(s) as admin";
 
 /* Password doesn't match */
 "Password doesn't match" = "Password doesn't match";

--- a/ArchipelClient/ModulesSources/ToolbarXMPPServer/Resources/en.lproj/Localizable.xstrings
+++ b/ArchipelClient/ModulesSources/ToolbarXMPPServer/Resources/en.lproj/Localizable.xstrings
@@ -22,8 +22,8 @@
 	<string>Create a new shared group</string>
 	<key>Delete selected shared group</key>
 	<string>Delete selected shared group</string>
-	<key>Grand selected user(s) as admin</key>
-	<string>Grand selected user(s) as admin</string>
+	<key>Grant selected user(s) as admin</key>
+	<string>Grant selected user(s) as admin</string>
 	<key>Password doesn't match</key>
 	<string>Password doesn't match</string>
 	<key>Register a new user</key>

--- a/ArchipelClient/ModulesSources/ToolbarXMPPServer/Resources/fr.lproj/Localizable.strings
+++ b/ArchipelClient/ModulesSources/ToolbarXMPPServer/Resources/fr.lproj/Localizable.strings
@@ -28,8 +28,8 @@
 /* Delete selected shared group */
 "Delete selected shared group" = "Delete selected shared group";
 
-/* Grand selected user(s) as admin */
-"Grand selected user(s) as admin" = "Grand selected user(s) as admin";
+/* Grant selected user(s) as admin */
+"Grant selected user(s) as admin" = "Grant selected user(s) as admin";
 
 /* Password doesn't match */
 "Password doesn't match" = "Password doesn't match";

--- a/ArchipelClient/ModulesSources/ToolbarXMPPServer/Resources/fr.lproj/Localizable.xstrings
+++ b/ArchipelClient/ModulesSources/ToolbarXMPPServer/Resources/fr.lproj/Localizable.xstrings
@@ -22,8 +22,8 @@
 	<string>Create a new shared group</string>
 	<key>Delete selected shared group</key>
 	<string>Delete selected shared group</string>
-	<key>Grand selected user(s) as admin</key>
-	<string>Grand selected user(s) as admin</string>
+	<key>Grant selected user(s) as admin</key>
+	<string>Grant selected user(s) as admin</string>
 	<key>Password doesn't match</key>
 	<string>Password doesn't match</string>
 	<key>Register a new user</key>

--- a/ArchipelClient/ModulesSources/ToolbarXMPPServer/TNXMPPUsersController.j
+++ b/ArchipelClient/ModulesSources/ToolbarXMPPServer/TNXMPPUsersController.j
@@ -213,7 +213,7 @@ var TNModuleControlForRegisterUser                  = @"RegisterUser",
                               image:CPImageInBundle(@"IconsButtons/user-remove.png",nil, [CPBundle mainBundle])];
 
         [_delegate addControlsWithIdentifier:TNModuleControlForGrantAdmin
-                              title:CPBundleLocalizedString(@"Grand selected user(s) as admin", @"Grand selected user(s) as admin")
+                              title:CPBundleLocalizedString(@"Grant selected user(s) as admin", @"Grant selected user(s) as admin")
                              target:self
                              action:@selector(grantAdmin:)
                               image:CPImageInBundle(@"IconsButtons/star.png",nil, [CPBundle mainBundle])];


### PR DESCRIPTION
Fixed a typo