### PR TITLE
Added sorting for list of hypervisor network interfaces

### DIFF
--- a/ArchipelAgent/archipel-agent-hypervisor-network/archipelagenthypervisornetwork/network.py
+++ b/ArchipelAgent/archipel-agent-hypervisor-network/archipelagenthypervisornetwork/network.py
@@ -237,7 +237,8 @@ class TNHypervisorNetworks (TNArchipelPlugin):
         content = f.read()
         f.close()
         splitted = content.split('\n')[2:-1]
-        return map(lambda x: x.split(":")[0].replace(" ", ""), splitted)
+        nics = map(lambda x: x.split(":")[0].replace(" ", ""), splitted)
+        return sorted(nics)
 
     def getnwfilters(self):
         """


### PR DESCRIPTION
The order of the network interfaces from getnics was the same order as displayed in /proc/net/dev.   In a host with sr-iov enabled there could be dozens of network interfaces listed.   sorting the list alphabetically is very helpful in using the pulldown.